### PR TITLE
Fixed example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,14 @@ You can get started quickly here with a simple example:
 ```python
 from numerous.engine import model, simulation
 from numerous.examples.dampened_oscillator.dampened_oscillator import OscillatorSystem
-import matplotlib.pyplot as plt
 #Define simulation
 s = simulation.Simulation(
      model.Model(OscillatorSystem('system')),
     t_start=0, t_stop=10, num=100, num_inner=100, max_step=0.1
 )
-#Solve and plot
+#Solve
 s.solve()
-s.model.historian_df.plot.line()
-plt.show()
+simulation_result = s.model.historian_df
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ You can get started quickly here with a simple example:
 
 ```python
 from numerous.engine import model, simulation
-from numerous.examples.dampened_oscillator import OscillatorSystem
-
+from numerous.examples.dampened_oscillator.dampened_oscillator import OscillatorSystem
+import matplotlib.pyplot as plt
 #Define simulation
 s = simulation.Simulation(
      model.Model(OscillatorSystem('system')),
@@ -40,7 +40,8 @@ s = simulation.Simulation(
 )
 #Solve and plot
 s.solve()
-s.model.historian.df.plot()
+s.model.historian_df.plot.line()
+plt.show()
 ```
 
 

--- a/examples/dampened_oscillator/dampened_oscillator.py
+++ b/examples/dampened_oscillator/dampened_oscillator.py
@@ -132,7 +132,7 @@ class OscillatorSystem2(Subsystem):
             self.register_items([spc3, te])
 
 class OscillatorSystem(Subsystem):
-    def __init__(self, tag, c=1, k=1, x0=[10, 8], a=1, n=1):
+    def __init__(self, tag, c=1, k=1, x0=[10, 8], a=1, n=2):
         super().__init__(tag)
         oscillators = []
         for i in range(n):


### PR DESCRIPTION
Default values in dampened oscillator example were causing it to fail when used with the example from the readme.
The readme example was also failing to import example files and produce a graph.